### PR TITLE
Fix NPE in HttpLoggingInterceptor when response has no body

### DIFF
--- a/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.java
@@ -230,8 +230,8 @@ public final class HttpLoggingInterceptor implements Interceptor {
     long tookMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
 
     ResponseBody responseBody = response.body();
-    boolean hasResponseBody = HttpHeaders.hasBody(response) && responseBody != null;
-    long contentLength = hasResponseBody ? responseBody.contentLength() : -1;
+    boolean hasResponseBody = HttpHeaders.hasBody(response) /*&& responseBody != null*/;
+    long contentLength = responseBody != null ? responseBody.contentLength() : -1;
     String bodySize = contentLength != -1 ? contentLength + "-byte" : "unknown-length";
     logger.log("<-- "
         + response.code()


### PR DESCRIPTION
When using the interceptor on a WebSocket it will throw a NPE.